### PR TITLE
docs(about.html): remove freenode

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,6 @@ This software contains portions by the following third parties:
 This software is used by:
 <ul>
 <li><a href="http://webchat.quakenet.org" rel="nofollow">QuakeNet</a></li>
-<li><a href="http://webchat.freenode.net" rel="nofollow">Freenode</a></li>
 <li><a href="http://chat.efnet.org:9090/" rel="nofollow">EFNet</a></li>
 <li><a href="http://irc.w3.org" rel="nofollow">The W3C</a></li>
 <li><a href="https://chat.wikileaks.org" rel="nofollow">Wikileaks</a></li>


### PR DESCRIPTION
freenode [announced](https://freenode.net/news/moving-to-kiwiirc), and have completed a change of webchat vendor to KiwiIRC. So the listing here is no longer accurate.